### PR TITLE
Change "feed" and add repository fork info

### DIFF
--- a/src/app/github/github-types.d.ts
+++ b/src/app/github/github-types.d.ts
@@ -8,10 +8,10 @@ export interface GithubRepositoryFromSource {
 	archived: boolean;
 	stargazers_count: number;
 	language?: string;
+	url: string;
 
 	fork: boolean;
-	forks_url?: string;
-	requested_forks?: GithubRepositoryFromSource
+	parent?: GithubRepositoryFromSource;
 
 	commits_url: string;
 	commit_count: number;
@@ -22,8 +22,6 @@ export type GithubRepository = Omit<
 	GithubRepositoryFromSource,
 	"commits_url" |
 	"forks_url" |
-	"requested_forks" |
+	"fork_repo" |
 	"fork"
-> & {
-	requested_forks?: GithubRepository
-};
+>;

--- a/src/app/github/route.ts
+++ b/src/app/github/route.ts
@@ -48,14 +48,14 @@ export async function GET(): Promise<NextResponse<GithubRepository[] | null>> {
 				continue;
 
 			const forkResponse: Response
-				= await fetch(repository.forks_url!, githubRequestInit);
+				= await fetch(repository.url!, githubRequestInit);
 
 			if (forkResponse.ok) {
-				const forkArray: GithubRepositoryFromSource[]
-					= (await forkResponse.json() satisfies GithubRepositoryFromSource[]);
+				const currentRespository: GithubRepositoryFromSource
+					= (await forkResponse.json() satisfies GithubRepositoryFromSource);
 
-				if (forkArray.length > 0)
-					repository.requested_forks = forkArray[0];
+				if (currentRespository.parent !== undefined)
+					repository.parent = currentRespository.parent;
 			}
 		}
 	}

--- a/src/app/page.css
+++ b/src/app/page.css
@@ -153,6 +153,10 @@ body {
     border: 1px solid red;
 
     animation: error-border linear infinite 2s;
+
+    @media (orientation: portrait) {
+        width: 80vw;
+    }
 }
 
 @keyframes error-border {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,8 +143,9 @@ export default function Home(): ReactElement {
 								href: "https://www.nuget.org/packages/MemwLib"
 							},
 							{
-								content: "Project server",
-								href: "https://discord.gg/vzgbCJBKHa"
+								content: "Coming soon...",
+								href: "https://discord.gg/vzgbCJBKHa",
+								disabled: true
 							}
 						]}
 					</FooterList>

--- a/src/components/footer-list/index.css
+++ b/src/components/footer-list/index.css
@@ -41,7 +41,11 @@
     }
 }
 
-.footer-link:hover {
+.footer-link[data-disabled='true'] {
+    color: #676767;
+}
+
+.footer-link:not([data-disabled='true']):hover {
     text-shadow: 0 0 5px;
 }
 
@@ -51,6 +55,6 @@
     transition: margin-right 0.2s;
 }
 
-.footer-link:hover > svg {
+.footer-link:not([data-disabled='true']):hover > svg {
     margin-right: 5px;
 }

--- a/src/components/footer-list/index.tsx
+++ b/src/components/footer-list/index.tsx
@@ -1,4 +1,4 @@
-import {ReactElement} from "react";
+import {MouseEvent, ReactElement} from "react";
 
 import {FaArrowRight} from "react-icons/fa6";
 
@@ -7,6 +7,7 @@ import "./index.css";
 interface Link {
 	content: string;
 	href: string;
+	disabled?: boolean;
 }
 
 interface FooterListProps extends Omit<BaseProps<HTMLDivElement>, "children">{
@@ -15,14 +16,21 @@ interface FooterListProps extends Omit<BaseProps<HTMLDivElement>, "children">{
 }
 
 export default function FooterList({title, children, className, ...props}: FooterListProps): ReactElement {
+	function avoidRedirectOnDisabled(event: MouseEvent<HTMLAnchorElement>) {
+		if ((event.target as HTMLAnchorElement).dataset.disabled === "true")
+			event.preventDefault();
+	}
+
 	return <div className={`footer-list ${className ?? ""}`} {...props}>
 		<h1>{title}</h1>
 		<div>
 			{children.map((link: Link, index: number): ReactElement =>
 				<a className="footer-link"
-				   href={link.href}
+				   data-disabled={link.disabled ?? false}
+				   href={link.disabled ? "/" : link.href}
 				   key={index}
 				   target="_blank"
+				   onClick={avoidRedirectOnDisabled}
 				>
 					<FaArrowRight />
 					{link.content}

--- a/src/components/repository/index.css
+++ b/src/components/repository/index.css
@@ -17,6 +17,8 @@
 
     font-size: 1.1em;
 
+    cursor: pointer;
+
     @media (orientation: portrait) {
         font-size: 1em;
     }

--- a/src/components/repository/index.tsx
+++ b/src/components/repository/index.tsx
@@ -1,4 +1,4 @@
-import {ReactElement} from "react";
+import {MutableRefObject, ReactElement, useRef} from "react";
 import {formatDistanceToNow} from "date-fns";
 import {If} from "babel-plugin-jsx-control-statements/components";
 
@@ -16,19 +16,25 @@ interface RepositoryProps extends Omit<BaseProps<HTMLDivElement>, "onClick"> {
 }
 
 export default function Repository({repository, className, ...props}: RepositoryProps): ReactElement {
+	const hoveringFork: MutableRefObject<boolean> = useRef(false);
+
 	function goToRepository(): void {
-		open(repository.html_url, "_blank");
+		if (!hoveringFork.current)
+			open(repository.html_url, "_blank");
 	}
 
 	return <Box onClick={goToRepository} className={`repository ${className ?? ""}`} {...props}>
 		<div className="repository-name">
 			<h1>{repository.name}</h1>
-			<If condition={repository.requested_forks !== undefined}>
+			<If condition={repository.parent !== undefined}>
 				<div className="repository-fork">
 					<FaCodeFork/>
-					<p>
-						Forked from <a href={repository.requested_forks!.html_url}>
-							{repository.requested_forks!.full_name}
+					<p
+						onMouseEnter={(): boolean => hoveringFork.current = true}
+						onMouseLeave={(): boolean => hoveringFork.current = false}
+					>
+						Forked from <a href={repository.parent!.html_url} target="_blank">
+							{repository.parent!.full_name}
 						</a>
 					</p>
 				</div>


### PR DESCRIPTION
# Features

- The feed has now changed, containing the most recent info about me.
- The repository view now features a `forked by` section, where you can directly access the parent repository.

# Fixes

- The possible error screen is now responsive.